### PR TITLE
Refine README to distinguish between mandatory and optional YAML fields

### DIFF
--- a/lib/data/README.md
+++ b/lib/data/README.md
@@ -2,6 +2,8 @@
 
 This directory contains YAML files that define various geospatial data sources. Each YAML file includes several fields that describe the data source's characteristics. Below is a description of each field:
 
+## Required Fields
+
 - `data_id`: A unique identifier for the data source.
 - `license`: The license under which the data is made available.
 - `attributions`: Credits or attributions required by the data provider.
@@ -9,21 +11,10 @@ This directory contains YAML files that define various geospatial data sources. 
 - `file_format`: The format of the data files (e.g., png, pbf).
 - `file_size`: The size of the data file, if known.
 - `url`: The URL where the data can be accessed.
+
+## Optional Fields
+
 - `max_zoom`: The maximum zoom level available for tile-based data sources.
 - `min_zoom`: The minimum zoom level available for tile-based data sources.
 
-## Examples
-
-Here are some examples to help you understand how to use these fields:
-
-- `data_id`: "gsi_xyz_english"
-- `license`: "CC-BY-4.0"
-- `attributions`: ["Geospatial Information Authority of Japan (GSI)", "https://maps.gsi.go.jp/development/ichiran.html"]
-- `description`: "The English version of the GSI's basic map (tile)"
-- `file_format`: "png"
-- `file_size`: "unknown"
-- `url`: "https://cyberjapandata.gsi.go.jp/xyz/english/{z}/{x}/{y}.png"
-- `max_zoom`: 11
-- `min_zoom`: 5
-
-Please replace the placeholders in the `url` field with appropriate values to access the data.
+Please ensure that all mandatory fields are filled out for each YAML file in this directory. Optional fields should be included if applicable and available.


### PR DESCRIPTION
Updates the `lib/data/README.md` to enhance clarity and compliance with project requirements.
- **Revises field descriptions:** Separates the fields into 'Required Fields' and 'Optional Fields' sections to clearly distinguish between mandatory and optional fields in the YAML files.
- **Removes examples section:** Deletes the examples section to focus the document on field specifications, aligning with the task's requirement to exclude examples.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g?shareId=1674365a-5f5a-45bd-b0fb-8beb7d4ed085).