### PR TITLE
Add GitHub Issue templates for bug report and data addition

### DIFF
--- a/UNopenGIS/foil4g/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/UNopenGIS/foil4g/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Bug Report
+
+## Describe the issue
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to Reproduce
+<!-- Steps to reproduce the behavior: -->
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Actual Behavior
+<!-- A clear and concise description of what actually happened. -->
+
+## Additional Context
+<!-- Add any other context about the problem here. -->

--- a/UNopenGIS/foil4g/.github/ISSUE_TEMPLATE/data_addition.md
+++ b/UNopenGIS/foil4g/.github/ISSUE_TEMPLATE/data_addition.md
@@ -1,0 +1,25 @@
+---
+name: Data Addition
+about: Suggest new data sources for inclusion
+title: ''
+labels: data addition
+assignees: ''
+
+---
+
+# Data Addition
+
+## Data Source Suggestion
+<!-- A clear and concise description of the data source you're suggesting. -->
+
+## Data Format
+<!-- Please specify the format of the data (e.g., CSV, GeoJSON). -->
+
+## License and Attribution
+<!-- Specify the license under which the data is made available. -->
+
+## URL
+<!-- Provide a URL where the data can be accessed or downloaded. -->
+
+## Additional Context
+<!-- Add any other context or screenshots about the data source suggestion here. -->


### PR DESCRIPTION
This pull request introduces two new GitHub Issue templates for the UNopenGIS/foil4g repository to streamline the process of reporting bugs and suggesting data additions.

- **Adds a bug report template**: This template guides users through reporting a bug by including sections for describing the issue, steps to reproduce, expected behavior, and actual behavior. It also includes metadata such as a default label for bug reports.
- **Adds a data addition template**: This template is designed for users to suggest new data sources for inclusion in the project. It prompts for details such as the data source description, format, license, and URL, along with a section for additional context.

These templates aim to improve the quality of issues submitted by providing structured formats for contributors to follow, making it easier for maintainers to understand and address the issues.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g?shareId=545269ea-582c-4d95-a509-762285fe8c57).