### PR TITLE
Add OpenStreetMap HOT style by OSM France as a data source

### DIFF
--- a/lib/data/tile.openstreetmap.fr/hot/index.yaml
+++ b/lib/data/tile.openstreetmap.fr/hot/index.yaml
@@ -1,0 +1,11 @@
+data_id: openstreetmap_fr_hot
+license: ODbL
+attributions:
+  - OpenStreetMap contributors
+  - https://www.openstreetmap.org/
+description: Raster tile map of OpenStreetMap by OpenStreetMap France. This map style is focused on resources useful for humanitarian organizations and citizens in general in emergency situations, highlighting POIs like water resources (water wells, manual pumps, fire hydrants...), light sources, public buildings, social buildings, roads quality, etc.
+file_format: png
+file_size: unknown
+url: https://{a|b}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png
+max_zoom: 19
+min_zoom: 0


### PR DESCRIPTION
Related to #7

Adds the OpenStreetMap HOT style by OSM France as a new data source in the repository.

- **Data Source Addition**: A new YAML file `lib/data/tile.openstreetmap.fr/hot/index.yaml` has been created to include the OpenStreetMap HOT style by OSM France as a data source.
- **Content Details**: The file specifies the `data_id`, `license` (ODbL), `attributions` to OpenStreetMap contributors, `description` of the map style, `file_format` (png), `file_size` (unknown), `url` pattern for accessing the tiles, and `max_zoom` and `min_zoom` levels.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/7?shareId=778bd0a9-9c05-4633-b6d3-f69a6771437a).