### PR TITLE
Add Code of Conduct to the repository

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, as well as in public spaces when an individual is representing the project or its community. Examples of representing our project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violation of these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the individuals involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violation of the terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We encourage contributions in the form of pull requests. Whether it's fixing a b
 
 Contributors to FOIL4G are expected to follow our Code of Conduct, which promotes a positive and inclusive environment. We are committed to providing a welcoming and respectful community for everyone.
 
-By participating in this project, you agree to abide by its terms.
+By participating in this project, you agree to abide by its terms. Please see our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file for more details.
 
 ## Questions?
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,4 +32,4 @@
 
 ## 貢献
 
-FOIL4G への貢献に興味がありますか？バグ報告、機能リクエスト、プルリクエストの提出方法、および従うべき行動規範の詳細については、[CONTRIBUTING.md](CONTRIBUTING.md) ファイルをご覧ください。
+FOIL4G への貢献に興味がありますか？バグ報告、機能リクエスト、プルリクエストの提出方法については、[CONTRIBUTING.md](CONTRIBUTING.md) ファイルをご覧ください。また、行動規範についての詳細は、[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) ファイルを参照してください。

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ In this way, FOIL4G applies Benjamin Franklin’s library concept to modern geos
 
 ## Contributing
 
-Interested in contributing to FOIL4G? We welcome contributions of all kinds from anyone. Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for more details on how to submit bug reports, feature requests, and pull requests, and what code of conduct to follow.
+Interested in contributing to FOIL4G? We welcome contributions of all kinds from anyone. Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for more details on how to submit bug reports, feature requests, and pull requests. For more information on our Code of Conduct, please refer to the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file.


### PR DESCRIPTION
Adds a new `CODE_OF_CONDUCT.md` file and updates documentation to reference it, enhancing the project's community guidelines and contribution process.

- **Adds `CODE_OF_CONDUCT.md`**: Introduces a new file adapted from the Contributor Covenant, version 2.1, establishing clear community standards and enforcement guidelines.
- **Updates `CONTRIBUTING.md`**: Modifies the Code of Conduct section to include a direct link to the new `CODE_OF_CONDUCT.md`, ensuring contributors are aware of the conduct guidelines.
- **Revises `README.md` and `README.ja.md`**: Both files are updated to reference the new Code of Conduct, making it accessible to both English and Japanese speaking contributors.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g?shareId=87819f9d-e0f6-4d7f-b016-d385fdd4522f).