### PR TITLE
Add ArcGIS World Imagery data source

### DIFF
--- a/lib/data/server.arcgisonline.com/world_imagery/index.yaml
+++ b/lib/data/server.arcgisonline.com/world_imagery/index.yaml
@@ -1,0 +1,11 @@
+data_id: arcgis_world_imagery
+license: unknown
+attributions:
+  - Esri, Maxar, Earthstar Geographics
+  - https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/
+description: Raster tile map of World Imagery by ArcGIS, Esri.
+file_format: png
+file_size: unknown
+url: https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}
+max_zoom: 22
+min_zoom: 0


### PR DESCRIPTION
- Close: #15

Adds the ArcGIS World Imagery data source to the repository.

- **Data Source Configuration**: Creates a new YAML file `lib/data/server.arcgisonline.com/world_imagery/index.yaml` with configuration for the ArcGIS World Imagery. This includes setting the `data_id` as `arcgis_world_imagery`, specifying the `license` as unknown, and defining the `file_format` as png.
- **Attributions and URL**: Adds attributions to Esri, Maxar, Earthstar Geographics with a link to the ArcGIS service. Provides the URL for accessing the World Imagery tiles.
- **Metadata**: Sets the `description` for the data source, indicating it is a raster tile map of World Imagery by ArcGIS, Esri. Also, specifies the `max_zoom` level as 22 and `min_zoom` as 0, with `file_size` marked as unknown.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/15?shareId=44d28764-2ab4-4fe1-b020-e51ba512b7a1).