### PR TITLE
Add Natural Earth coastline 1:10m data source

### DIFF
--- a/lib/data/www.naturalearthdata.com/ne_10m_coastline/index.yaml
+++ b/lib/data/www.naturalearthdata.com/ne_10m_coastline/index.yaml
@@ -1,0 +1,9 @@
+data_id: ne_10m_coastline
+license: public domain
+attributions:
+  - Natural Earth
+  - https://www.naturalearthdata.com/
+description: Zipped shapefile of the coastline at a 1:10m scale from Natural Earth
+file_format: zipped_shapefile
+file_size: 2.9MB
+url: http//www.naturalearthdata.com/download/10m/physical/ne_10m_coastline.zip


### PR DESCRIPTION
- Close: #18

Adds a new YAML file to the repository to include the Natural Earth coastline data at a 1:10m scale.
- Adds `lib/data/www.naturalearthdata.com/ne_10m_coastline/index.yaml` defining the data source with attributes such as `data_id`, `license`, `attributions`, `description`, `file_format`, `file_size`, and `url`.
- Specifies the data as a zipped shapefile of the coastline at a 1:10m scale from Natural Earth, under public domain license, with attributions to Natural Earth and their website.
- Lists the file size as 2.9MB and provides a direct download URL for the zipped shapefile.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/18?shareId=82a70989-ec46-4c23-ba8d-58730998807a).