### PR TITLE
Add Nominatim API definitions

### DIFF
--- a/lib/api/nominatim.openstreetmap.org/reverse/index.yaml
+++ b/lib/api/nominatim.openstreetmap.org/reverse/index.yaml
@@ -1,0 +1,20 @@
+api_id: nominatim_reverse
+description: Nominatim is a tool to search OSM data by name and address geocoding and to generate synthetic addresses of OSM points (reverse geocoding).
+endpoint_url: https://nominatim.openstreetmap.org/reverse
+parameters:
+  - name: format
+    description: The format of the response, e.g., jsonv2.
+    required: true
+    type: string
+  - name: lat
+    description: Latitude of the location to reverse geocode.
+    required: true
+    type: float
+  - name: lon
+    description: Longitude of the location to reverse geocode.
+    required: true
+    type: float
+  - name: zoom
+    description: Level of detail required for the response, e.g., 10.
+    required: false
+    type: integer

--- a/lib/api/nominatim.openstreetmap.org/search/index.yaml
+++ b/lib/api/nominatim.openstreetmap.org/search/index.yaml
@@ -1,0 +1,12 @@
+api_id: nominatim_search
+description: Nominatim is a tool to search OSM data by name and address geocoding and to generate synthetic addresses of OSM points (reverse geocoding).
+endpoint_url: https://nominatim.openstreetmap.org/search
+parameters:
+  - name: format
+    description: The format of the response, e.g., jsonv2.
+    required: true
+    type: string
+  - name: q
+    description: The search query, e.g., a place name or address.
+    required: true
+    type: string


### PR DESCRIPTION
- Close: #25

Adds the Nominatim API to the repository with the API definition split into two YAML files as specified in the issue.

- **Search API Definition**: Adds `lib/api/nominatim.openstreetmap.org/search/index.yaml` with fields for `api_id`, `description`, `endpoint_url`, and `parameters` including `format` and `q` to define the search functionality of the Nominatim API.
- **Reverse API Definition**: Adds `lib/api/nominatim.openstreetmap.org/reverse/index.yaml` with fields for `api_id`, `description`, `endpoint_url`, and `parameters` including `format`, `lat`, `lon`, and `zoom` to define the reverse geocoding functionality of the Nominatim API.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/25?shareId=012bdaa1-c996-4f62-a766-dbba882902c0).