### PR TITLE
Add `data_format` field for YAML files in `lib/data/`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "Geographics",
     "hinanbasho",
     "Maxar",
+    "naturalearthdata",
     "openstreetmap",
     "seamlessphoto",
     "shapefile",

--- a/lib/data/README.md
+++ b/lib/data/README.md
@@ -8,7 +8,8 @@ This directory contains YAML files that define various geospatial data sources. 
 - `license`: The license under which the data is made available.
 - `attributions`: Credits or attributions required by the data provider.
 - `description`: A brief description of the data source.
-- `file_format`: The format of the data files (e.g., png, pbf).
+- `data_format`: The format of the data (e.g., xyz_raster_tiles, xyz_vector_tiles, pmtiles).
+- `file_format`: The format of the data files (e.g., png, pbf, pmtiles).
 - `file_size`: The size of the data file, if known.
 - `url`: The URL where the data can be accessed.
 

--- a/lib/data/cyberjapandata.gsi.go.jp/xyz/english/index.yaml
+++ b/lib/data/cyberjapandata.gsi.go.jp/xyz/english/index.yaml
@@ -7,6 +7,7 @@ attributions:
   - 海上保安庁許可第292502号（水路業務法第25条に基づく類似刊行物）
   - "Shoreline data is derived from: United States. National Imagery and Mapping Agency. \"Vector Map Level 0 (VMAP0).\" Bethesda, MD: Denver, CO: The Agency; USGS Information Services, 1997."
 description: The English version of the GSI's basic map (tile)
+data_format: xyz_raster_tiles
 file_format: png
 file_size: unknown
 url: https://cyberjapandata.gsi.go.jp/xyz/english/{z}/{x}/{y}.png

--- a/lib/data/cyberjapandata.gsi.go.jp/xyz/pale/index.yaml
+++ b/lib/data/cyberjapandata.gsi.go.jp/xyz/pale/index.yaml
@@ -5,6 +5,7 @@ attributions:
   - https://maps.gsi.go.jp/development/ichiran.html
   - "Shoreline data is derived from: United States. National Imagery and Mapping Agency. \"Vector Map Level 0 (VMAP0).\" Bethesda, MD: Denver, CO: The Agency; USGS Information Services, 1997."
 description: 国土地理院の基本測量成果（名称：電子地形図（タイル））
+data_format: xyz_raster_tiles
 file_format: png
 file_size: unknown
 url: https://cyberjapandata.gsi.go.jp/xyz/pale/{z}/{x}/{y}.png

--- a/lib/data/cyberjapandata.gsi.go.jp/xyz/relief/index.yaml
+++ b/lib/data/cyberjapandata.gsi.go.jp/xyz/relief/index.yaml
@@ -5,6 +5,7 @@ attributions:
   - https://maps.gsi.go.jp/development/ichiran.html
   - 海域部は海上保安庁海洋情報部の資料を使用して作成
 description: 国土地理院の色別標高図（タイル）
+data_format: xyz_raster_tiles
 file_format: png
 file_size: unknown
 url: https://cyberjapandata.gsi.go.jp/xyz/relief/{z}/{x}/{y}.png

--- a/lib/data/cyberjapandata.gsi.go.jp/xyz/seamlessphoto/index.yaml
+++ b/lib/data/cyberjapandata.gsi.go.jp/xyz/seamlessphoto/index.yaml
@@ -6,6 +6,7 @@ attributions:
   - データソース：Landsat8画像（GSI,TSIC,GEO Grid/AIST）, Landsat8画像（courtesy of the U.S. Geological Survey）, 海底地形（GEBCO）
   - Images on 世界衛星モザイク画像 obtained from site https://lpdaac.usgs.gov/data_access maintained by the NASA Land Processes Distributed Active Archive Center (LP DAAC), USGS/Earth Resources Observation and Science (EROS) Center, Sioux Falls, South Dakota, (Year). Source of image data product.
 description: 国土地理院の全国最新写真（シームレス）、	全国ランドサットモザイク画像、	世界衛星モザイク画像。
+data_format: xyz_raster_tiles
 file_format: png
 file_size: unknown
 url: https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.png

--- a/lib/data/cyberjapandata.gsi.go.jp/xyz/std/index.yaml
+++ b/lib/data/cyberjapandata.gsi.go.jp/xyz/std/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - 国土地理院
   - https://maps.gsi.go.jp/development/ichiran.html
 description: 国土地理院の基本測量成果（名称：電子地形図（タイル））
+data_format: xyz_raster_tiles
 file_format: png
 file_size: unknown
 url: https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png

--- a/lib/data/data.source.coop/smartmaps/toshik/index.yaml
+++ b/lib/data/data.source.coop/smartmaps/toshik/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - 国土交通省都市局都市計画課都市計画調査室
   - https://www.mlit.go.jp/toshi/tosiko/toshi_tosiko_tk_000087.html
 description: 都市計画決定GISデータ（国土交通省）をPMTiles形式に加工したもの
+data_format: pmtiles
 file_format: pmtiles
 file_size: 152MB
 url: https://data.source.coop/smartmaps/toshik/a.pmtiles

--- a/lib/data/download.geofabrik.de/asia/japan/index.yaml
+++ b/lib/data/download.geofabrik.de/asia/japan/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - Geofabrik GmbH
   - OpenStreetMap Contributors
 description: OpenStreetMap data extracts for Japan.
+data_format: osm_pbf
 file_format: pbf
 file_size: unknown
 url: https://download.geofabrik.de/asia/japan-latest.osm.pbf

--- a/lib/data/download.geofabrik.de/asia/japan/kanto/index.yaml
+++ b/lib/data/download.geofabrik.de/asia/japan/kanto/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - Geofabrik GmbH
   - OpenStreetMap Contributors
 description: OpenStreetMap data extracts for Kanto, Japan.
+data_format: osm_pbf
 file_format: pbf
 file_size: unknown
 url: https://download.geofabrik.de/asia/japan/kanto-latest.osm.pbf

--- a/lib/data/download.geofabrik.de/europe/monaco/index.yaml
+++ b/lib/data/download.geofabrik.de/europe/monaco/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - Geofabrik GmbH
   - OpenStreetMap Contributors
 description: OpenStreetMap data extracts for Monaco.
+data_format: osm_pbf
 file_format: pbf
 file_size: unknown
 url: https://download.geofabrik.de/europe/monaco-latest.osm.pbf

--- a/lib/data/server.arcgisonline.com/world_imagery/index.yaml
+++ b/lib/data/server.arcgisonline.com/world_imagery/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - Esri, Maxar, Earthstar Geographics
   - https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/
 description: Raster tile map of World Imagery by ArcGIS, Esri.
+data_format: xyz_raster_tiles
 file_format: png
 file_size: unknown
 url: https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}

--- a/lib/data/tile.openstreetmap.fr/hot/index.yaml
+++ b/lib/data/tile.openstreetmap.fr/hot/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - OpenStreetMap contributors
   - https://www.openstreetmap.org/
 description: Raster tile map of OpenStreetMap by OpenStreetMap France. This map style is focused on resources useful for humanitarian organizations and citizens in general in emergency situations, highlighting POIs like water resources (water wells, manual pumps, fire hydrants...), light sources, public buildings, social buildings, roads quality, etc.
+data_format: xyz_raster_tiles
 file_format: png
 file_size: unknown
 url: https://{a|b}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png

--- a/lib/data/tile.openstreetmap.jp/osm-bright/index.yaml
+++ b/lib/data/tile.openstreetmap.jp/osm-bright/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - OpenStreetMap contributors
   - https://www.openstreetmap.org/
 description: Vector tile map of OpenStreetMap by OSMFJ
-file_format: style_json
+data_format: vector_tile_style_json
+file_format: json
 file_size: unknown
 url: https://tile.openstreetmap.jp/styles/osm-bright/style.json

--- a/lib/data/tile.openstreetmap.jp/planet/index.yaml
+++ b/lib/data/tile.openstreetmap.jp/planet/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - OpenStreetMap contributors
   - https://www.openstreetmap.org/
 description: Vector tile map of OpenStreetMap by OSMFJ
+data_format: xyz_vector_tiles
 file_format: pbf
 file_size: unknown
 url: https://tile.openstreetmap.jp/data/planet/{z}/{x}/{y}.pbf

--- a/lib/data/tile.openstreetmap.jp/planet_pmtiles/index.yaml
+++ b/lib/data/tile.openstreetmap.jp/planet_pmtiles/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - OpenStreetMap contributors
   - https://www.openstreetmap.org/
 description: PMTiles format map of OpenStreetMap by OSMFJ
+data_format: pmtiles
 file_format: pmtiles
 file_size: 67GB
 url: https://tile.openstreetmap.jp/static/planet.pmtiles

--- a/lib/data/tile.openstreetmap.org/index.yaml
+++ b/lib/data/tile.openstreetmap.org/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - OpenStreetMap contributors
   - https://www.openstreetmap.org/
 description: Raster tile map of OpenStreetMap
+data_format: xyz_raster_tiles
 file_format: png
 file_size: unknown
 url: https://tile.openstreetmap.org/{z}/{x}/{y}.png

--- a/lib/data/ucdp.uu.se/ged231-csv.zip/index.yaml
+++ b/lib/data/ucdp.uu.se/ged231-csv.zip/index.yaml
@@ -3,6 +3,7 @@ license: CC-BY-4.0
 attributions:
   - Uppsala Conflict Data Program
 description: Armed conflict data from the Uppsala Conflict Data Program (UCDP).
-file_format: zipped_csv
+data_format: zipped_csv
+file_format: zip
 file_size: 23MB
 url: https://ucdp.uu.se/downloads/ged231-csv.zip

--- a/lib/data/www.geospatial.jp/hinanbasho/index.yaml
+++ b/lib/data/www.geospatial.jp/hinanbasho/index.yaml
@@ -5,6 +5,7 @@ attributions:
   - https://www.gsi.go.jp/bousaichiri/hinanbasho.html
   - AIGID
 description: 国土地理院の提供している全国指定避難場所をShapefile化したデータ
-file_format: zipped_shapefile
+data_format: zipped_shapefile
+file_format: zip
 file_size: 4MB
 url: https://www.geospatial.jp/ckan/dataset/db74071f-cd0a-406d-ba3d-57c7a25d9925/resource/4db1e885-f688-4a92-aec0-f9ebf960c402/download/00.zip

--- a/lib/data/www.naturalearthdata.com/ne_10m_coastline/index.yaml
+++ b/lib/data/www.naturalearthdata.com/ne_10m_coastline/index.yaml
@@ -4,6 +4,7 @@ attributions:
   - Natural Earth
   - https://www.naturalearthdata.com/
 description: Zipped shapefile of the coastline at a 1:10m scale from Natural Earth
-file_format: zipped_shapefile
+data_format: zipped_shapefile
+file_format: zip
 file_size: 2.9MB
 url: http//www.naturalearthdata.com/download/10m/physical/ne_10m_coastline.zip


### PR DESCRIPTION
## What this pull request will change

- Add `data_format` field for YAML files in `lib/data/`

## Why that change is needed

- `file_format` は、そのフィールド名のとおり、データのファイルフォーマットのみを正確に表現するべきである
- そうすると、 `file_format` だけではデータの具体的なフォーマットの説明として不十分である
- `data_format` フィールドを追加する

