### PR TITLE
Add Vientiane land use data

### DIFF
--- a/lib/data/optgeo.github.io/virgo-data/20200122_vcc_landuse_final_2015.yaml
+++ b/lib/data/optgeo.github.io/virgo-data/20200122_vcc_landuse_final_2015.yaml
@@ -1,0 +1,10 @@
+data_id: optgeo_vcc_landuse_final_2015
+license: unknown
+attributions:
+  - Vientiane Integrated Urban Information GIS-based Opendata Platform
+  - https://virgo.mpwt.gov.la/disclaimer/#/
+description: Land use data for Vientiane, Lao P. D. R., for the year 2015
+data_format: shapefile
+file_format: shp
+file_size: unknown
+url: https://optgeo.github.io/virgo-data/20200122_vcc_landuse_final_2015.shp


### PR DESCRIPTION
- Close: #45

Adds metadata for the Vientiane, Lao P. D. R., land use data for the year 2015 to the repository.
- Introduces a new YAML file `lib/data/optgeo.github.io/virgo-data/20200122_vcc_landuse_final_2015.yaml` containing detailed metadata about the land use data.
- Specifies `data_id` as `optgeo_vcc_landuse_final_2015`.
- Sets the `license` field to `unknown`.
- Includes `attributions` to the Vientiane Integrated Urban Information GIS-based Opendata Platform with a URL link.
- Describes the data as land use information for Vientiane for the year 2015.
- Defines `data_format` as `shapefile` and `file_format` as `shp`.
- Marks `file_size` as `unknown`.
- Provides the source URL for the data.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/45?shareId=24fe14fc-1c80-44bc-b6bc-7b45abd824d3).