### PR TITLE
Add 22kv underground line future plan data

### DIFF
--- a/lib/data/optgeo.github.io/virgo-data/22kv_underground_line_future_plan_v1.yaml
+++ b/lib/data/optgeo.github.io/virgo-data/22kv_underground_line_future_plan_v1.yaml
@@ -1,0 +1,10 @@
+data_id: optgeo_22kv_underground_line_future_plan_v1
+license: unknown
+attributions:
+  - Vientiane Integrated Urban Information GIS-based Opendata Platform
+  - https://virgo.mpwt.gov.la/disclaimer/#/
+description: land use data for Vientiane, Lao P. D. R.
+data_format: shapefile
+file_format: shp
+file_size: unknown
+url: https://optgeo.github.io/virgo-data/22kv_underground_line_future_plan_v1.shp


### PR DESCRIPTION
- Close: #46

Adds a new YAML file for the `22kv_underground_line_future_plan_v1.shp` data to the repository.

- **File Addition**: Creates `lib/data/optgeo.github.io/virgo-data/22kv_underground_line_future_plan_v1.yaml` to include metadata for the shapefile data.
- **Metadata Details**: Specifies `data_id`, `license`, `attributions`, `description`, `data_format`, `file_format`, `file_size`, and `url` as per the issue description, ensuring proper documentation and accessibility of the data.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/46?shareId=48c94938-842b-439d-94af-d0cd68401dc3).