### PR TITLE
Add determining road data for Vientiane

### DIFF
--- a/lib/data/optgeo.github.io/virgo-data/determiningroad_v0.yaml
+++ b/lib/data/optgeo.github.io/virgo-data/determiningroad_v0.yaml
@@ -1,0 +1,10 @@
+data_id: optgeo_determiningroad_v0
+license: unknown
+attributions:
+  - Vientiane Integrated Urban Information GIS-based Opendata Platform
+  - https://virgo.mpwt.gov.la/disclaimer/#/
+description: Determining road data for Vientiane, Lao P. D. R.
+data_format: shapefile
+file_format: shp
+file_size: unknown
+url: https://optgeo.github.io/virgo-data/determiningroad_v0.shp


### PR DESCRIPTION
- Close: #48

Adds a new YAML file to the repository to include metadata for the determining road data for Vientiane, Lao P. D. R.

- **Metadata Addition**: Introduces `lib/data/optgeo.github.io/virgo-data/determiningroad_v0.yaml` containing essential metadata such as data ID, license status (unknown), attributions to Vientiane Integrated Urban Information GIS-based Opendata Platform, description of the data, data format (shapefile), file format (shp), file size (unknown), and the URL for data access.
- **Attribution Details**: Specifies dual attributions, including a link to the disclaimer page of the Vientiane Integrated Urban Information GIS-based Opendata Platform, acknowledging the source of the data.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/48?shareId=cbe95273-8d56-45a7-a0b4-46f358df3110).