### PR TITLE
Add electric pole data for Vientiane

### DIFF
--- a/lib/data/optgeo.github.io/virgo-data/electric_pole_point_v1.yaml
+++ b/lib/data/optgeo.github.io/virgo-data/electric_pole_point_v1.yaml
@@ -1,0 +1,8 @@
+data_id: optgeo_electric_pole_point_v1
+license: unknown
+attributions: Vientiane Integrated Urban Information GIS-based Opendata Platform
+description: electric pole data for Vientiane, Lao P. D. R.
+data_format: shapefile
+file_format: shp
+file_size: unknown
+url: https://optgeo.github.io/virgo-data/electric_pole_point_v1.shp


### PR DESCRIPTION
- Close: #51

Adds a new YAML file for electric pole data in Vientiane, Lao P. D. R. to the repository.
- Introduces `lib/data/optgeo.github.io/virgo-data/electric_pole_point_v1.yaml` with comprehensive details about the electric pole data.
- Specifies fields such as `data_id`, `license`, `attributions`, `description`, `data_format`, `file_format`, `file_size`, and `url`, aligning with the structure of existing data files in the repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/51?shareId=64b3570f-fbe7-4099-8a76-b53d496f068e).