### PR TITLE
Add electric 22kV VTC line data for Vientiane

### DIFF
--- a/lib/data/optgeo.github.io/virgo-data/electric_22kv_vtc_line_v1.yaml
+++ b/lib/data/optgeo.github.io/virgo-data/electric_22kv_vtc_line_v1.yaml
@@ -1,0 +1,10 @@
+data_id: electric_22kv_vtc_line_v1
+license: unknown
+attributions:
+  - Vientiane Integrated Urban Information GIS-based Opendata Platform
+  - https://virgo.mpwt.gov.la/disclaimer/#/
+description: Electric 22kV VTC line data for Vientiane, Lao P. D. R.
+data_format: shapefile
+file_format: shp
+file_size: unknown
+url: https://optgeo.github.io/virgo-data/electric_22kv_vtc_line_v1.shp


### PR DESCRIPTION
- Close: #49

Adds a new YAML file to include the electric 22kV VTC line data for Vientiane, Lao P. D. R. in the repository.

- **File Addition**: Creates `lib/data/optgeo.github.io/virgo-data/electric_22kv_vtc_line_v1.yaml` to store metadata about the electric 22kV VTC line data.
- **Metadata Fields**: Specifies `data_id`, `license`, `attributions`, `description`, `data_format`, `file_format`, `file_size`, and `url` within the new YAML file.
- **Content Details**: Sets the `license` as unknown, lists the Vientiane Integrated Urban Information GIS-based Opendata Platform under `attributions`, and provides a URL to the Shapefile data.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/49?shareId=c8e59912-691b-4441-b719-09151245f44c).