### PR TITLE
Add fire hydrant data for Vientiane

### DIFF
--- a/lib/data/optgeo.github.io/virgo-data/firehydrant_2023_v1.yaml
+++ b/lib/data/optgeo.github.io/virgo-data/firehydrant_2023_v1.yaml
@@ -1,0 +1,10 @@
+data_id: optgeo_firehydrant_2023_v1
+license: unknown
+attributions:
+  - Vientiane Integrated Urban Information GIS-based Opendata Platform
+  - https://virgo.mpwt.gov.la/disclaimer/#/
+description: Fire hydrant data for Vientiane, Lao P. D. R., for the year 2023
+data_format: shapefile
+file_format: shp
+file_size: unknown
+url: https://optgeo.github.io/virgo-data/firehydrant_2023_v1.shp


### PR DESCRIPTION
- Close: #53

Adds a new YAML file `firehydrant_2023_v1.yaml` to the `lib/data/optgeo.github.io/virgo-data/` directory to include metadata about the fire hydrant data for Vientiane, Lao P. D. R., for the year 2023.

- **Metadata Details**: Specifies the data ID, license as unknown, attributions to the Vientiane Integrated Urban Information GIS-based Opendata Platform, and a description of the data.
- **Data Format**: Indicates the data format as shapefile, with the file format specified as `.shp`.
- **Data Source**: Includes the URL to the shapefile data.
- **Additional Information**: Lists file size as unknown.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/53?shareId=34ada644-9922-44ee-a33d-c94b92796b12).