### PR TITLE
Add government office data for Vientiane

### DIFF
--- a/lib/data/optgeo.github.io/virgo-data/goverment_office_v0.yaml
+++ b/lib/data/optgeo.github.io/virgo-data/goverment_office_v0.yaml
@@ -1,0 +1,10 @@
+data_id: optgeo_goverment_office_v0
+license: unknown
+attributions:
+  - Vientiane Integrated Urban Information GIS-based Opendata Platform
+  - https://virgo.mpwt.gov.la/disclaimer/#/
+description: government office data for Vientiane, Lao P. D. R.
+data_format: shapefile
+file_format: shp
+file_size: unknown
+url: https://optgeo.github.io/virgo-data/goverment_office_v0.shp


### PR DESCRIPTION
- Close: #55

Adds a new YAML file to include government office data for Vientiane, Lao P. D. R. in the repository.
- Introduces `lib/data/optgeo.github.io/virgo-data/goverment_office_v0.yaml` with comprehensive details including a unique data identifier, license status, attributions to the Vientiane Integrated Urban Information GIS-based Opendata Platform, and a description of the data.
- Specifies the data format as shapefile and file format as shp, with the file size marked as unknown.
- Provides a URL to access the government office data directly.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/55?shareId=48a73ea3-facd-4ffa-90a2-cb60495b7603).