### PR TITLE
Add transmission line data for Vientiane

### DIFF
--- a/lib/data/optgeo.github.io/virgo-data/transmission_line_v1.yaml
+++ b/lib/data/optgeo.github.io/virgo-data/transmission_line_v1.yaml
@@ -1,0 +1,10 @@
+data_id: optgeo_transmission_line_v1
+license: unknown
+attributions:
+  - Vientiane Integrated Urban Information GIS-based Opendata Platform
+  - https://virgo.mpwt.gov.la/disclaimer/#/
+description: Transmission line data for Vientiane, Lao P. D. R.
+data_format: shapefile
+file_format: shp
+file_size: unknown
+url: https://optgeo.github.io/virgo-data/transmission_line_v1.shp


### PR DESCRIPTION
- Close: #63

Adds a new YAML file for the transmission line data in Vientiane, Lao P. D. R. to the `lib/data/optgeo.github.io/virgo-data` directory.

- **File Creation**: Creates `transmission_line_v1.yaml` with detailed metadata about the transmission line data.
- **Metadata Fields**: Includes fields for `data_id`, `license`, `attributions`, `description`, `data_format`, `file_format`, `file_size`, and `url`, providing comprehensive information about the data source, format, and access.
- **Data Source and Format**: Specifies the data format as "shapefile" and the file format as "shp", with a direct URL to access the shapefile data.
- **License and Attribution**: Marks the license as "unknown" but notes the data's intention to be open, attributing it to the Vientiane Integrated Urban Information GIS-based Opendata Platform with a link to their disclaimer page.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UNopenGIS/foil4g/issues/63?shareId=09c9427d-7227-4d41-ba2f-d3ea7267ead5).