### PR TITLE
refactor: import map as `MapComponent`

### DIFF
--- a/src/components/Datasets/ArmedConflict/index.stories.ts
+++ b/src/components/Datasets/ArmedConflict/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { ArmedConflictMap } from ".";
+import { ArmedConflictMap as MapComponent } from ".";
 
-const meta = {
-  component: ArmedConflictMap,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof ArmedConflictMap>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof ArmedConflictMap>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Datasets/DEM1A/index.stories.ts
+++ b/src/components/Datasets/DEM1A/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { DEM1AMap } from ".";
+import { DEM1AMap as MapComponent } from ".";
 
-const meta = {
-  component: DEM1AMap,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof DEM1AMap>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof DEM1AMap>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Datasets/GEL/index.stories.ts
+++ b/src/components/Datasets/GEL/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { GELMap } from '.';
+import { GELMap as MapComponent } from '.';
 
-const meta: Meta<typeof GELMap> = {
-  component: GELMap,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof GELMap>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof GELMap>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Datasets/OpenCellId/index.stories.ts
+++ b/src/components/Datasets/OpenCellId/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { OpenCellId } from ".";
+import { OpenCellId as MapComponent } from ".";
 
-const meta = {
-  component: OpenCellId,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof OpenCellId>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof OpenCellId>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Datasets/OvertureMaps/index.stories.ts
+++ b/src/components/Datasets/OvertureMaps/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { OvertureMaps } from ".";
+import { OvertureMaps as MapComponent } from ".";
 
-const meta = {
-  component: OvertureMaps,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof OvertureMaps>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof OvertureMaps>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Datasets/Rwanda10/index.stories.ts
+++ b/src/components/Datasets/Rwanda10/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Rwanda10Map } from ".";
+import { Rwanda10Map as MapComponent } from ".";
 
-const meta = {
-  component: Rwanda10Map,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof Rwanda10Map>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof Rwanda10Map>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Datasets/VientianeLanduse/index.stories.ts
+++ b/src/components/Datasets/VientianeLanduse/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { VientianeLanduseMap } from ".";
+import { VientianeLanduseMap as MapComponent } from ".";
 
-const meta = {
-  component: VientianeLanduseMap,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof VientianeLanduseMap>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof VientianeLanduseMap>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Maps/OpenStreetMap/OpenStreetMapFrHotRaster/index.stories.ts
+++ b/src/components/Maps/OpenStreetMap/OpenStreetMapFrHotRaster/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { OpenStreetMapFrHotRaster } from ".";
+import { OpenStreetMapFrHotRaster as MapComponent } from ".";
 
-const meta = {
-  component: OpenStreetMapFrHotRaster,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof OpenStreetMapFrHotRaster>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof OpenStreetMapFrHotRaster>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Maps/OpenStreetMap/OpenStreetMapJpOSMBrightVector/index.stories.ts
+++ b/src/components/Maps/OpenStreetMap/OpenStreetMapJpOSMBrightVector/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { OpenStreetMapJpOSMBrightVector } from ".";
+import { OpenStreetMapJpOSMBrightVector as MapComponent} from ".";
 
-const meta = {
-  component: OpenStreetMapJpOSMBrightVector,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof OpenStreetMapJpOSMBrightVector>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof OpenStreetMapJpOSMBrightVector>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Maps/OpenStreetMap/OpenStreetMapOrgRaster/index.stories.ts
+++ b/src/components/Maps/OpenStreetMap/OpenStreetMapOrgRaster/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { OpenStreetMapOrgRaster } from ".";
+import { OpenStreetMapOrgRaster as MapComponent } from ".";
 
-const meta = {
-  component: OpenStreetMapOrgRaster,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof OpenStreetMapOrgRaster>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof OpenStreetMapOrgRaster>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Maps/SatelliteImagery/ArcGISWorldImagery/index.stories.ts
+++ b/src/components/Maps/SatelliteImagery/ArcGISWorldImagery/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { ArcGISWorldImagery } from ".";
+import { ArcGISWorldImagery as MapComponent } from ".";
 
-const meta = {
-  component: ArcGISWorldImagery,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof ArcGISWorldImagery>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof ArcGISWorldImagery>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Maps/SatelliteImagery/GSISeamlessPhoto/index.stories.ts
+++ b/src/components/Maps/SatelliteImagery/GSISeamlessPhoto/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { GSISeamlessPhoto } from ".";
+import { GSISeamlessPhoto as MapComponent } from ".";
 
-const meta = {
-  component: GSISeamlessPhoto,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof GSISeamlessPhoto>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof GSISeamlessPhoto>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};

--- a/src/components/Maps/UNClearMapRaster/index.stories.ts
+++ b/src/components/Maps/UNClearMapRaster/index.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { UNClearMapRaster } from ".";
+import { UNClearMapRaster as MapComponent } from ".";
 
-const meta = {
-  component: UNClearMapRaster,
+const meta: Meta<typeof MapComponent> = {
+  component: MapComponent,
   parameters: {
-    layout: "fullscreen",
+    layout: 'fullscreen',
   },
-} satisfies Meta<typeof UNClearMapRaster>;
+} satisfies Meta<typeof MapComponent>;
 
 export default meta;
-type Story = StoryObj<typeof UNClearMapRaster>;
+type Story = StoryObj<typeof MapComponent>;
 
 export const Preview: Story = {};


### PR DESCRIPTION
## What this pull request will change

- 名前付きimportを `as MapComponent` とすることでコードを共通化する

## Why that change is needed

- GitHub Copilot Workspaceがコードを理解しやすくするため

