### PR TITLE
Update Ollama workflow to use Docker for model management and invocation

### DIFF
--- a/.github/workflows/ollama.yml
+++ b/.github/workflows/ollama.yml
@@ -11,32 +11,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Make ollama models directory
+      - name: Run Ollama Docker image and pull gemma2:2b
         run: |
           mkdir -p ~/.ollama/models
-      - name: Cache Ollama dir
-        id: cache-ollama
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.ollama
-            ~/.ollama/models
-          key: ${{ runner.os }}-ollama
-      - name: Install Ollama
-        run: |
-          curl -fsSL https://ollama.com/install.sh | sudo -E sh
-          sudo systemctl stop ollama.service
-      - name: Start serving
-        run: |
-            OLLAMA_MODELS=~/.ollama/models ollama serve &
-            sleep 5
-            time curl -i http://localhost:11434
-      - name: Pull gemma2:2b
-        run: |
-            OLLAMA_MODELS=~/.ollama/models ollama pull gemma2:2b
-      - name: Output ~/.ollama/models
-        run: |
-            ls -alh ~/.ollama/models
+          docker run -d -v ollama:/home/runner/.ollama -p 11434:11434 --name ollama ollama/ollama
+          sleep 20
+          docker exec ollama ollama pull gemma2:2b
+          sleep 20
+          time curl -i http://localhost:11434
       - name: Invoke gemma2:2b
         run: |
-            OLLAMA_MODELS=~/.ollama/models ollama run gemma2:2b "Who is the current President of the United States?"
+          docker exec ollama ollama run gemma2:2b "Who is the current Secretary General of the United Nations?"


### PR DESCRIPTION
This pull request updates the `.github/workflows/ollama.yml` file to streamline the setup and execution of the Ollama Docker image. The most important changes include replacing the manual installation and setup steps with Docker commands.

Key changes:

* Replaced the manual creation of the Ollama models directory and the caching of the Ollama directory with a Docker volume mount.
* Removed the steps to install and start Ollama manually, replacing them with commands to run the Ollama Docker image and pull the `gemma2:2b` model.
* Updated the command to invoke the `gemma2:2b` model to ask a different question: "Who is the current Secretary General of the United Nations?"
