### PR TITLE
docs: READMEの実装セクションの改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ In this way, FOIL4G applies Benjamin Franklin’s library concept to modern geos
 
 ## Implementation
 
+- `src`: Core React components and application logic for the web-based mapping interface
 - `lib`
   - `api`: API for accessing geospatial information
   - `data`: Details for referencing geospatial information
-  - `skills`: Skills for handling geospatial information
-  - `tasks`: Tasks for processing and analyzing geospatial information
+  - `tasks`: Tasks for processing, analyzing, and transforming geospatial information
 
 ## Contributing
 


### PR DESCRIPTION
# READMEの実装セクションの改善

## 変更内容
- `src` ディレクトリの情報を追加し、Reactコンポーネントとアプリケーションロジックの説明を含めました
- `tasks` ディレクトリの説明を更新し、より正確な情報を提供
- 未使用の `skills` ディレクトリの記述を削除

## テスト状況
Readmeの実装セクションの改善Readme

Link to Devin run: https://app.devin.ai/sessions/9d315949d5ce4962aa31caa9dd2490a4
