### PR TITLE
feat: add lib/commands dir

### DIFF
--- a/lib/commands/gdal/gdal_translate.ja.md
+++ b/lib/commands/gdal/gdal_translate.ja.md
@@ -1,0 +1,44 @@
+# gdal_translate
+
+> ラスターデータセットを別の形式に変換するGDALユーティリティ。
+> フォーマット変換、リサイズ、リサンプリング、データ型変換などが可能です。
+> 詳細: https://gdal.org/programs/gdal_translate.html
+
+- 基本的な使用法（フォーマット変換例：GeoTIFFからJPEGに変換）:
+  `gdal_translate -of JPEG path/to/input.tif path/to/output.jpg`
+
+- 出力サイズを指定（ピクセル数を指定）:
+  `gdal_translate -outsize 800 600 path/to/input.tif path/to/output.tif`
+
+- 出力サイズを元のサイズに対する割合で指定（50%に縮小）:
+  `gdal_translate -outsize 50% 50% path/to/input.tif path/to/output.tif`
+
+- 出力データ型を変更（例：Float32からInt16へ）:
+  `gdal_translate -ot Int16 path/to/input.tif path/to/output.tif`
+
+- ノーデータ値を設定（透明部分や欠損値の指定）:
+  `gdal_translate -a_nodata 0 path/to/input.tif path/to/output.tif`
+
+- 特定の範囲を切り出し（左上X, 左上Y, 右下X, 右下Yの順）:
+  `gdal_translate -projwin 440720 3751320 441920 3750120 path/to/input.tif path/to/output.tif`
+
+- 圧縮オプションを指定（LZW圧縮を使用）:
+  `gdal_translate -co COMPRESS=LZW path/to/input.tif path/to/output.tif`
+
+- 特定のバンドのみを抽出（例：3バンドのデータから1番目と3番目のバンドのみ抽出）:
+  `gdal_translate -b 1 -b 3 path/to/input.tif path/to/output.tif`
+
+- スケーリングを適用（元の値の範囲[0,1000]を新しい範囲[0,255]に変換）:
+  `gdal_translate -scale 0 1000 0 255 path/to/input.tif path/to/output.tif`
+
+- 特定の座標系に変換（EPSG:4326に変換）:
+  `gdal_translate -a_srs EPSG:4326 path/to/input.tif path/to/output.tif`
+
+- メタデータを追加:
+  `gdal_translate -mo "AUTHOR=GIS専門家" path/to/input.tif path/to/output.tif`
+
+- オーバービューの作成（ピラミッド作成）:
+  `gdal_translate -outsize 50% 50% -co "COPY_SRC_OVERVIEWS=YES" path/to/input.tif path/to/output.tif`
+
+- クラウドストレージからのデータを変換:
+  `gdal_translate /vsicurl/https://example.com/path/to/input.tif path/to/output.tif`

--- a/lib/commands/gdal/gdalinfo.ja.md
+++ b/lib/commands/gdal/gdalinfo.ja.md
@@ -1,0 +1,35 @@
+# gdalinfo
+
+> ラスターデータセットの情報を表示するGDALユーティリティ。
+> GDALでサポートされている様々な形式のラスターデータの情報を取得できます。
+> 詳細: https://gdal.org/programs/gdalinfo.html
+
+- 基本的な使用法（ファイルの情報を表示）:
+  `gdalinfo path/to/input.tif`
+
+- 全てのメタデータを表示:
+  `gdalinfo -stats path/to/input.tif`
+
+- 座標系情報をWKT形式で表示:
+  `gdalinfo -wkt path/to/input.tif`
+
+- 座標系情報をPROJ.4形式で表示:
+  `gdalinfo -proj4 path/to/input.tif`
+
+- ファイルの統計情報を表示（最小値、最大値、平均値、標準偏差など）:
+  `gdalinfo -stats path/to/input.tif`
+
+- ファイルの情報をJSON形式で出力:
+  `gdalinfo -json path/to/input.tif`
+
+- ピクセル値のヒストグラムを表示:
+  `gdalinfo -hist path/to/input.tif`
+
+- 指定したバンドのみの情報を表示（例：バンド1）:
+  `gdalinfo -band 1 path/to/input.tif`
+
+- マルチスレッド処理を有効化（大きなファイル向け）:
+  `gdalinfo --config GDAL_NUM_THREADS 4 path/to/large_input.tif`
+
+- HTTPやクラウドストレージ上のファイルの情報を取得:
+  `gdalinfo /vsicurl/https://example.com/path/to/file.tif`

--- a/lib/commands/gdal/gdalwarp.ja.md
+++ b/lib/commands/gdal/gdalwarp.ja.md
@@ -1,0 +1,47 @@
+# gdalwarp
+
+> ラスターデータセットの空間変換とリプロジェクションを行うGDALユーティリティ。
+> 座標系変換、リサンプリング、モザイク化などの高度な処理を実行できます。
+> 詳細: https://gdal.org/programs/gdalwarp.html
+
+- 基本的な使用法（座標系を変換：UTM座標系からWGS84緯度経度へ）:
+  `gdalwarp -t_srs EPSG:4326 path/to/input.tif path/to/output.tif`
+
+- 出力範囲を指定（左下x 左下y 右上x 右上yの順）:
+  `gdalwarp -te 440720 3750120 441920 3751320 path/to/input.tif path/to/output.tif`
+
+- リサンプリング方法を指定（最近傍法、バイリニア、キュービック、他）:
+  `gdalwarp -r bilinear path/to/input.tif path/to/output.tif`
+
+- 出力解像度を設定（メートル単位）:
+  `gdalwarp -tr 30 30 path/to/input.tif path/to/output.tif`
+
+- 複数の入力ファイルをモザイク化して一つのファイルに統合:
+  `gdalwarp path/to/input1.tif path/to/input2.tif path/to/output.tif`
+
+- 出力ファイルの作成オプションを指定（LZW圧縮を使用）:
+  `gdalwarp -co COMPRESS=LZW path/to/input.tif path/to/output.tif`
+
+- マルチスレッド処理を使用（4つのスレッドを使用）:
+  `gdalwarp -multi -wo NUM_THREADS=4 path/to/input.tif path/to/output.tif`
+
+- ノーデータ値の設定（例：値0をノーデータとして指定）:
+  `gdalwarp -srcnodata 0 -dstnodata 0 path/to/input.tif path/to/output.tif`
+
+- 出力を特定のサイズに切り抜く（100x100ピクセル）:
+  `gdalwarp -ts 100 100 path/to/input.tif path/to/output.tif`
+
+- カットライン（ベクターファイル）を使用して切り抜き:
+  `gdalwarp -cutline path/to/cutline.shp -crop_to_cutline path/to/input.tif path/to/output.tif`
+
+- 複数の入力バンドからVRTを作成（仮想モザイク）:
+  `gdalwarp -of VRT path/to/input1.tif path/to/input2.tif path/to/output.vrt`
+
+- 出力ファイルの地理変換行列（GeoTransform）を上書き設定:
+  `gdalwarp -gcp 0 0 440720 3751320 -gcp 0 100 440720 3750320 -gcp 100 0 441720 3751320 path/to/input.tif path/to/output.tif`
+
+- 入力データの周囲に余白（バッファ）を追加:
+  `gdalwarp -wo CUTLINE_ALL_TOUCHED=TRUE -srcnodata 0 -dstnodata 0 path/to/input.tif path/to/output.tif`
+
+- 極性変換（北極・南極の変換）:
+  `gdalwarp -s_srs "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs" -t_srs EPSG:4326 path/to/input.tif path/to/output.tif`

--- a/lib/commands/gdal/ogr2ogr.ja.md
+++ b/lib/commands/gdal/ogr2ogr.ja.md
@@ -1,0 +1,47 @@
+# ogr2ogr
+
+> ベクターデータセットの変換・加工を行うOGRユーティリティ。
+> フォーマット変換、座標系変換、属性操作、空間フィルタリングなどが可能です。
+> 詳細: https://gdal.org/programs/ogr2ogr.html
+
+- 基本的な使用法（フォーマット変換例：ShapefileからGeoJSONへ）:
+  `ogr2ogr -f GeoJSON output.geojson input.shp`
+
+- 座標系を変換（例：EPSG:4326からEPSG:3857へ）:
+  `ogr2ogr -s_srs EPSG:4326 -t_srs EPSG:3857 output.shp input.shp`
+
+- 特定のレイヤーのみを変換:
+  `ogr2ogr -f GeoJSON output.geojson input.gpkg -sql "SELECT * FROM layer_name"`
+
+- SQLを使用して特定の条件に合うフィーチャーのみを抽出:
+  `ogr2ogr -f GeoJSON output.geojson input.shp -where "population > 10000"`
+
+- PostGISデータベースからデータをエクスポート:
+  `ogr2ogr -f "ESRI Shapefile" output.shp PG:"host=localhost user=user dbname=gisdb password=pwd" -sql "SELECT * FROM schema.table"`
+
+- データをPostGISデータベースにインポート:
+  `ogr2ogr -f PostgreSQL PG:"host=localhost user=user dbname=gisdb password=pwd" input.shp -nln schema.table_name`
+
+- 特定の属性フィールドのみを選択:
+  `ogr2ogr -f GeoJSON output.geojson input.shp -select "field1,field2,field3"`
+
+- 空間フィルタを適用（特定の範囲内のデータのみを抽出）:
+  `ogr2ogr -f GeoJSON output.geojson input.shp -spat xmin ymin xmax ymax`
+
+- 複数のファイルを一つに結合:
+  `ogr2ogr -f "ESRI Shapefile" merged.shp input1.shp && ogr2ogr -f "ESRI Shapefile" -update -append merged.shp input2.shp -nln merged`
+
+- 属性フィールド名を変更:
+  `ogr2ogr -f GeoJSON output.geojson input.shp -sql "SELECT field1 AS new_name1, field2 AS new_name2 FROM input"`
+
+- ジオメトリタイプを変換（例：ポリゴンからライン）:
+  `ogr2ogr -f GeoJSON output.geojson input.shp -nlt LINESTRING`
+
+- 出力を圧縮:
+  `ogr2ogr -f "ESRI Shapefile" -dsco SPATIALITE=YES output.sqlite input.shp`
+
+- データがない場合でも出力レイヤーを作成:
+  `ogr2ogr -f GeoJSON output.geojson input.shp -nln new_layer_name -lco SPATIAL_INDEX=YES`
+
+- CSVファイルを座標付きのGeoJSONに変換:
+  `ogr2ogr -f GeoJSON output.geojson input.csv -oo X_POSSIBLE_NAMES=lon* -oo Y_POSSIBLE_NAMES=lat* -a_srs EPSG:4326`

--- a/lib/commands/gdal/ogrinfo.ja.md
+++ b/lib/commands/gdal/ogrinfo.ja.md
@@ -1,0 +1,47 @@
+# ogrinfo
+
+> ベクターデータセットの情報を表示するOGRユーティリティ。
+> OGRでサポートされている様々な形式のベクターデータの情報を取得できます。
+> 詳細: https://gdal.org/programs/ogrinfo.html
+
+- 基本的な使用法（ファイルの情報とレイヤー一覧を表示）:
+  `ogrinfo path/to/vector.shp`
+
+- 特定のレイヤーの詳細情報を表示:
+  `ogrinfo path/to/vector.shp layer_name`
+
+- ファイル内の全てのレイヤーの詳細情報を表示:
+  `ogrinfo -al path/to/vector.shp`
+
+- フィーチャーカウントのみを表示:
+  `ogrinfo -so path/to/vector.shp layer_name`
+
+- 特定のフィーチャーの情報を表示（IDを指定）:
+  `ogrinfo path/to/vector.shp layer_name -fid 1`
+
+- 属性とジオメトリの要約情報を表示:
+  `ogrinfo -so -al path/to/vector.shp`
+
+- 空間的な範囲（エンベロープ）のみを表示:
+  `ogrinfo -so -al -where "1=1" path/to/vector.shp`
+
+- SQL文を使用して条件に合うフィーチャーの情報を表示:
+  `ogrinfo -sql "SELECT * FROM layer_name WHERE attribute = 'value'" path/to/vector.shp`
+
+- ベクターデータの座標系情報を表示:
+  `ogrinfo -al -so path/to/vector.shp`
+
+- フォーマットを指定してファイルを開く（例：GeoJSON）:
+  `ogrinfo -f GeoJSON path/to/vector.geojson`
+
+- 出力をCSV形式で取得:
+  `ogrinfo -al -fo CSV path/to/vector.shp`
+
+- データベース接続からレイヤー情報を表示（例：PostGIS）:
+  `ogrinfo PG:"host=localhost user=user dbname=gisdb password=password" schema.table_name`
+
+- ネットワーク上のデータを表示（WFS等）:
+  `ogrinfo WFS:http://example.com/geoserver/wfs`
+
+- 特定のフィールドの値だけを表示:
+  `ogrinfo -sql "SELECT DISTINCT field_name FROM layer_name" path/to/vector.shp`


### PR DESCRIPTION
This pull request adds comprehensive Japanese documentation for several GDAL and OGR command-line utilities. Each file provides detailed usage examples, options, and explanations for various functionalities. These changes enhance the accessibility of these tools for Japanese-speaking users.

### GDAL Utilities Documentation:

* [`lib/commands/gdal/gdal_translate.ja.md`](diffhunk://#diff-3a43d9e5bb2e815a0845e5953c7f4e59e263204a056096a4278c0732c3f08df6R1-R44): Added documentation for `gdal_translate`, covering format conversion, resizing, data type changes, and other operations.
* [`lib/commands/gdal/gdalinfo.ja.md`](diffhunk://#diff-d4ff5583dc1f3e885ec56c54885f7ec63e94f1ab020b8659be9f8ec4b7914f1bR1-R35): Added documentation for `gdalinfo`, detailing how to retrieve raster dataset metadata, statistics, and spatial information.
* [`lib/commands/gdal/gdalwarp.ja.md`](diffhunk://#diff-d1fad1a5760ca639f39cf387dbe4b6dc7d1338190c35bcac4557e437307c6c4bR1-R47): Added documentation for `gdalwarp`, including spatial transformations, reprojections, and advanced processing like mosaicking and cropping.

### OGR Utilities Documentation:

* [`lib/commands/gdal/ogr2ogr.ja.md`](diffhunk://#diff-137d2fffb438bd69a429684d4cd614f622ad35a5c420e3ae5e0f63a63132617fR1-R47): Added documentation for `ogr2ogr`, explaining vector data format conversion, spatial filtering, attribute manipulation, and database interactions.
* [`lib/commands/gdal/ogrinfo.ja.md`](diffhunk://#diff-e2840ecd4627c7cf26eeb52c310020704c4e8ff1c979e122a02fbd918edd9e16R1-R47): Added documentation for `ogrinfo`, focusing on extracting vector dataset metadata, layer details, and spatial queries.