### PR TITLE
Add lib/commands/tippecanoe/tippecanoe.ja.md

### DIFF
--- a/lib/commands/gdal/ogr2ogr.ja.md
+++ b/lib/commands/gdal/ogr2ogr.ja.md
@@ -45,3 +45,9 @@
 
 - CSVファイルを座標付きのGeoJSONに変換:
   `ogr2ogr -f GeoJSON output.geojson input.csv -oo X_POSSIBLE_NAMES=lon* -oo Y_POSSIBLE_NAMES=lat* -a_srs EPSG:4326`
+
+- GeoJSONシーケンス形式(GeoJSONSeq)で出力:
+  `ogr2ogr -f GeoJSONSeq output.geojsonl input.shp`
+
+- GeoJSONシーケンス形式で出力し、改行区切りの各フィーチャーを処理:
+  `ogr2ogr -of GeoJSONSeq output.geojsonl input.shp`

--- a/lib/commands/gdal/ogr2ogr.ja.md
+++ b/lib/commands/gdal/ogr2ogr.ja.md
@@ -48,6 +48,3 @@
 
 - GeoJSONシーケンス形式(GeoJSONSeq)で出力:
   `ogr2ogr -f GeoJSONSeq output.geojsonl input.shp`
-
-- GeoJSONシーケンス形式で出力し、改行区切りの各フィーチャーを処理:
-  `ogr2ogr -of GeoJSONSeq output.geojsonl input.shp`

--- a/lib/commands/tippecanoe/tippecanoe.ja.md
+++ b/lib/commands/tippecanoe/tippecanoe.ja.md
@@ -1,0 +1,66 @@
+# tippecanoe
+
+> 大規模（または小規模）なGeoJSON、FlatGeobuf、CSVなどのデータからベクトルタイルセットを構築するツール。
+> あらゆるズームレベルでデータの密度と特性を維持し、効率的なベクタータイルを生成します。
+> 詳細: https://github.com/felt/tippecanoe
+
+- 基本的な使用法（GeoJSONからMBTilesへの変換）:
+  `tippecanoe -o output.mbtiles input.geojson`
+
+- 自動的に適切なズームレベルを選択し、必要に応じて密度の高い地域のフィーチャーを間引く:
+  `tippecanoe -zg -o output.mbtiles --drop-densest-as-needed input.geojson`
+
+- 特定のズームレベル範囲を指定（最小ズーム0から最大ズーム14まで）:
+  `tippecanoe -z14 -Z0 -o output.mbtiles input.geojson`
+
+- レイヤー名とレイヤーの説明を指定:
+  `tippecanoe -o output.mbtiles -l layer_name -n "Layer description" input.geojson`
+
+- 複数の入力ファイルを別々のレイヤーとして追加:
+  `tippecanoe -o output.mbtiles -L layer1:input1.geojson -L layer2:input2.geojson`
+
+- タイルサイズの上限を変更（デフォルトは500KB）:
+  `tippecanoe -o output.mbtiles -M 1000000 input.geojson`
+
+- 特定の属性のみを保持し、他の属性を削除:
+  `tippecanoe -o output.mbtiles -x excluded_attribute -y included_attribute input.geojson`
+
+- 属性に基づいてフィルタリング:
+  `tippecanoe -o output.mbtiles -j '{"*":["any",["==","property","value"]]}' input.geojson`
+
+- 密度の高い領域でフィーチャーを間引く:
+  `tippecanoe -o output.mbtiles --drop-densest-as-needed input.geojson`
+
+- 空間のフィルタリング（バウンディングボックス内のデータのみを処理）:
+  `tippecanoe -o output.mbtiles --clip-bounding-box=minlon,minlat,maxlon,maxlat input.geojson`
+
+- ジオメトリの簡略化レベルを設定（デフォルトは12）:
+  `tippecanoe -o output.mbtiles -d 10 input.geojson`
+
+- PMTiles形式で出力:
+  `tippecanoe -o output.pmtiles input.geojson`
+
+- フィーチャーIDを生成:
+  `tippecanoe -o output.mbtiles -ai input.geojson`
+
+- CSVファイルを座標を持つGeoJSONに変換してからタイル化:
+  `tippecanoe -o output.mbtiles --csv-points input.csv --csv-lat-field latitude --csv-lon-field longitude`
+
+- カスタム一時ディレクトリを指定:
+  `tippecanoe -o output.mbtiles -t /path/to/temp/dir input.geojson`
+
+## tile-join
+
+tile-join は、既存のベクトルタイルセット（.mbtiles、.pmtiles、ディレクトリ）を結合したり、CSV ファイルから新しい属性を追加したりするためのツールです。
+
+- 複数のMBTilesファイルを結合:
+  `tile-join -o combined.mbtiles input1.mbtiles input2.mbtiles input3.mbtiles`
+
+- CSVファイルの属性を既存のフィーチャーに結合:
+  `tile-join -o with_attributes.mbtiles -c attributes.csv input.mbtiles`
+
+- レイヤー名を変更:
+  `tile-join -o renamed.mbtiles -r old_name:new_name input.mbtiles`
+
+- フィルタを適用して特定のフィーチャーのみを含める:
+  `tile-join -o filtered.mbtiles -j '{"*":["none",["==","property","value"]]}' input.mbtiles`


### PR DESCRIPTION
This pull request adds new documentation examples for two geospatial data processing tools, `ogr2ogr` and `tippecanoe`, in their respective Japanese-language markdown files. The changes include new usage examples and explanations for advanced features.

### Updates to `ogr2ogr` documentation:
* Added examples for outputting GeoJSON in sequence format (GeoJSONSeq) and processing newline-delimited features. (`lib/commands/gdal/ogr2ogr.ja.md`, [lib/commands/gdal/ogr2ogr.ja.mdR48-R53](diffhunk://#diff-137d2fffb438bd69a429684d4cd614f622ad35a5c420e3ae5e0f63a63132617fR48-R53))

### New `tippecanoe` documentation:
* Introduced a new section with detailed usage examples for `tippecanoe`, covering tasks like converting GeoJSON to MBTiles, setting zoom levels, filtering attributes, and simplifying geometries. (`lib/commands/tippecanoe/tippecanoe.ja.md`, [lib/commands/tippecanoe/tippecanoe.ja.mdR1-R66](diffhunk://#diff-dd42e4d723bb4916bb10ff0c033ba54840bc857e07ee553a6afd18861a790771R1-R66))
* Added a subsection for `tile-join`, explaining how to merge vector tilesets, add attributes from CSV files, rename layers, and apply filters. (`lib/commands/tippecanoe/tippecanoe.ja.md`, [lib/commands/tippecanoe/tippecanoe.ja.mdR1-R66](diffhunk://#diff-dd42e4d723bb4916bb10ff0c033ba54840bc857e07ee553a6afd18861a790771R1-R66))