### PR TITLE
docs: add Japanese documentation for gdalbuildvrt and gdal2tiles.py

### DIFF
--- a/lib/commands/gdal/gdal2tiles.py.ja.md
+++ b/lib/commands/gdal/gdal2tiles.py.ja.md
@@ -1,0 +1,38 @@
+# gdal2tiles.py
+
+> ラスターデータをウェブマップタイル（XYZ または TMS）に変換するGDALユーティリティ。
+> Google Maps、OpenLayers、Leaflet などで使用可能なタイルセットを生成します。
+> 詳細: https://gdal.org/programs/gdal2tiles.html
+
+- 基本的な使用法（ラスターファイルからタイルを生成）:
+  `gdal2tiles.py input.tif output_directory/`
+
+- Webメルカトル（EPSG:3857）でタイルを生成:
+  `gdal2tiles.py -s EPSG:4326 -z 1-10 -w all input.tif output_directory/`
+
+- GoogleマップやOpenStreetMap互換（XYZ）タイルを生成:
+  `gdal2tiles.py -w all -p mercator input.tif output_directory/`
+
+- TMS（Tile Map Service）形式でタイルを生成:
+  `gdal2tiles.py -p geodetic input.tif output_directory/`
+
+- 特定のズームレベル範囲のタイルのみを生成:
+  `gdal2tiles.py -z 10-15 input.tif output_directory/`
+
+- マルチプロセス処理でタイル生成を高速化（例：4プロセス）:
+  `gdal2tiles.py -p mercator --processes=4 input.tif output_directory/`
+
+- リサンプリングメソッドを指定してタイルを生成:
+  `gdal2tiles.py -r bilinear input.tif output_directory/`
+
+- サムネイル画像（KML SuperOverlay用）も生成:
+  `gdal2tiles.py -p mercator --kml input.tif output_directory/`
+
+- タイルにカスタムNoData値を設定:
+  `gdal2tiles.py --srcnodata 255 --nodata 0 input.tif output_directory/`
+
+- 簡易的なWebビューアを生成（Leaflet、OpenLayers、Google Maps）:
+  `gdal2tiles.py -w all -p mercator input.tif output_directory/`
+
+- VRTファイルを入力として使用（複数ファイルのタイル化）:
+  `gdal2tiles.py input.vrt output_directory/`

--- a/lib/commands/gdal/gdalbuildvrt.ja.md
+++ b/lib/commands/gdal/gdalbuildvrt.ja.md
@@ -1,0 +1,35 @@
+# gdalbuildvrt
+
+> 複数のラスターデータセットから仮想ラスターデータセット（VRT）を構築するGDALユーティリティ。
+> VRTはデータを複製せずに複数のラスターデータを仮想的に結合します。
+> 詳細: https://gdal.org/programs/gdalbuildvrt.html
+
+- 基本的な使用法（複数のファイルからVRTを作成）:
+  `gdalbuildvrt output.vrt input1.tif input2.tif input3.tif`
+
+- ディレクトリ内の全てのTIFファイルからVRTを作成:
+  `gdalbuildvrt output.vrt path/to/directory/*.tif`
+
+- ファイルリストからVRTを作成:
+  `gdalbuildvrt output.vrt -input_file_list file_list.txt`
+
+- 複数のファイルをモザイク（結合）してVRTを作成:
+  `gdalbuildvrt -resolution highest output.vrt *.tif`
+
+- 特定のバンドのみを使用してVRTを作成:
+  `gdalbuildvrt -b 1 -b 3 output.vrt input.tif`
+
+- 画像のオーバーラップ部分の処理方法を指定（最初、最後、平均、最大値など）:
+  `gdalbuildvrt -srcnodata 0 -vrtnodata 0 -resolution highest output.vrt *.tif`
+
+- 時系列データセットからマルチバンドVRTを作成（各ファイルが1つのバンドになる）:
+  `gdalbuildvrt -separate output.vrt time1.tif time2.tif time3.tif`
+
+- 出力範囲を指定してVRTを作成:
+  `gdalbuildvrt -te xmin ymin xmax ymax output.vrt *.tif`
+
+- 特定の空間参照系でVRTを作成:
+  `gdalbuildvrt -a_srs EPSG:4326 output.vrt *.tif`
+
+- NoDataの値を指定してVRTを作成:
+  `gdalbuildvrt -srcnodata 255 -vrtnodata 0 output.vrt *.tif`


### PR DESCRIPTION
This pull request adds comprehensive documentation in Japanese for two GDAL utilities, `gdal2tiles.py` and `gdalbuildvrt`. These documents provide detailed usage examples and options for each utility, making it easier for Japanese-speaking users to understand and utilize these tools.

### Added Documentation for GDAL Utilities:

* **`gdal2tiles.py` Documentation**:
  - Explains how to convert raster data into web map tiles (XYZ or TMS) compatible with platforms like Google Maps, OpenLayers, and Leaflet.
  - Includes examples for generating tiles with specific zoom levels, projections, resampling methods, and more.

* **`gdalbuildvrt` Documentation**:
  - Describes how to create virtual raster datasets (VRT) from multiple raster files without duplicating data.
  - Provides examples for creating VRTs with specific bands, resolutions, spatial references, and handling NoData values.