### PR TITLE
Add React Leaflet example

### DIFF
--- a/README.claude.md
+++ b/README.claude.md
@@ -64,6 +64,7 @@ foil4g/
 1. `maplibre-gl`: メインマッピングライブラリ
 2. `pmtiles`: 効率的なタイルストレージフォーマット
 3. `react-map-gl`: MapLibre GLのReactラッパー
+4. `react-leaflet`: LeafletをReactで利用するラッパー
 
 ## APIとデータ構造
 

--- a/README.devin.md
+++ b/README.devin.md
@@ -58,6 +58,7 @@ foil4g/
 1. `maplibre-gl`: Main mapping library
 2. `pmtiles`: Efficient tile storage format
 3. `react-map-gl`: React wrapper for MapLibre GL
+4. `react-leaflet`: React wrapper for Leaflet
 
 ## Contributing
 

--- a/docs/repositories/github.com/PaulLeCam/react-leaflet/react-leaflet.md
+++ b/docs/repositories/github.com/PaulLeCam/react-leaflet/react-leaflet.md
@@ -1,0 +1,13 @@
+# react-leaflet
+
+> react-leaflet は、人気の地図ライブラリ [[Leaflet]] を [[React]] で扱えるようにするコンポーネント集です。
+
+Leaflet の API を React コンポーネントの形で提供し、宣言的な地図表現を可能にします。OpenStreetMap などのタイルレイヤや各種オーバーレイを簡単に追加でき、React の状態管理と組み合わせたインタラクティブな地図アプリケーションの構築に適しています。
+
+詳細なドキュメントや利用方法については、[公式リポジトリ](https://github.com/PaulLeCam/react-leaflet)を参照してください。
+
+## 関連情報
+
+-   [[Leaflet]]
+-   [[React]]
+-   [GitHubリポジトリ](https://github.com/PaulLeCam/react-leaflet)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "foil4g",
       "version": "0.0.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "maplibre-gl": "^4.4.0",
         "pmtiles": "^3.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-leaflet": "^4.2.1",
         "react-map-gl": "^7.1.7"
       },
       "devDependencies": {
@@ -1296,6 +1298,17 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -4892,6 +4905,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5631,6 +5650,20 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/react-map-gl": {
       "version": "7.1.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "pmtiles": "^3.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-map-gl": "^7.1.7"
+    "react-map-gl": "^7.1.7",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.0",

--- a/src/examples/Leaflet/BasicMap/index.stories.ts
+++ b/src/examples/Leaflet/BasicMap/index.stories.ts
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { BasicLeafletMap } from ".";
+
+const meta = {
+  component: BasicLeafletMap,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof BasicLeafletMap>;
+
+export default meta;
+
+type Story = StoryObj<typeof BasicLeafletMap>;
+
+export const Preview: Story = {};

--- a/src/examples/Leaflet/BasicMap/index.tsx
+++ b/src/examples/Leaflet/BasicMap/index.tsx
@@ -1,0 +1,17 @@
+import { MapContainer, TileLayer } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+
+export const BasicLeafletMap = () => {
+  return (
+    <MapContainer
+      center={[0, 0]}
+      zoom={2}
+      style={{ width: "100%", height: "100%" }}
+    >
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution="&copy; OpenStreetMap contributors"
+      />
+    </MapContainer>
+  );
+};


### PR DESCRIPTION
## Summary
- add leaflet and react-leaflet dependencies
- provide BasicLeafletMap example and Storybook entry
- document react-leaflet library
- mention react-leaflet in project READMEs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684159f2889c832592ad7f7ae64ec686