### PR TITLE
Add react-google-maps example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "foil4g",
       "version": "0.0.0",
       "dependencies": {
+        "@vis.gl/react-google-maps": "^1.5.2",
         "leaflet": "^1.9.4",
         "maplibre-gl": "^4.4.0",
         "pmtiles": "^3.0.6",
@@ -2369,6 +2370,12 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2699,6 +2706,20 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.5.2.tgz",
+      "integrity": "sha512-0Ypmde7M73GgV4TgcaUTNKXsbcXWToPVuawMNrVg7htXmhpEfLARHwhtmP6N1da3od195ZKC8ShXzC6Vm+zYHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.4.0",
@@ -3965,7 +3986,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@vis.gl/react-google-maps": "^1.5.2",
+    "leaflet": "^1.9.4",
     "maplibre-gl": "^4.4.0",
     "pmtiles": "^3.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-map-gl": "^7.1.7",
-    "leaflet": "^1.9.4",
-    "react-leaflet": "^4.2.1"
+    "react-leaflet": "^4.2.1",
+    "react-map-gl": "^7.1.7"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.0",

--- a/src/examples/GoogleMaps/BasicMap/index.stories.ts
+++ b/src/examples/GoogleMaps/BasicMap/index.stories.ts
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { BasicGoogleMap } from ".";
+
+const meta: Meta<typeof BasicGoogleMap> = {
+  component: BasicGoogleMap,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BasicGoogleMap>;
+
+export const Preview: Story = {};

--- a/src/examples/GoogleMaps/BasicMap/index.tsx
+++ b/src/examples/GoogleMaps/BasicMap/index.tsx
@@ -1,0 +1,13 @@
+import { APIProvider, Map } from "@vis.gl/react-google-maps";
+
+export const BasicGoogleMap = () => {
+  return (
+    <APIProvider apiKey="YOUR_API_KEY">
+      <Map
+        defaultCenter={{ lat: 0, lng: 0 }}
+        defaultZoom={2}
+        style={{ width: "100%", height: "100%" }}
+      />
+    </APIProvider>
+  );
+};


### PR DESCRIPTION
## Summary
- add Basic Google Maps example component and Storybook story
- install `@vis.gl/react-google-maps` dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68415b6f6294832595deb6f253e70557